### PR TITLE
Updated dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: ci
 on:
   push:
     # Publish pep440 tags as releases.
+    branches: [ "master" ]
     tags: [ '*.*.*' ]
   pull_request:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,4 @@ simplejson~=3.19.2
 async_gpib~=2.1.2
 hp3478a_async~=1.4.1
 tinkerforge_async~=1.4.3
-labnode_async~=0.16.2
+labnode_async~=0.16.3


### PR DESCRIPTION
-  labnode_async to make sure the fix for [CVE-2024-26134](https://github.com/advisories/GHSA-375g-39jq-vq7m) is included
- Rebuild docker image on push to master