### PR TITLE
List the CPU used to compile the binary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,9 @@ jobs:
           - platform: ${{ (startsWith(github.ref, 'refs/tags/') && 'nothing') || (github.event_name == 'pull_request' && 'nothing') || 'linux/arm/v6' }}
           - platform: ${{ (startsWith(github.ref, 'refs/tags/') && 'nothing') || (github.event_name == 'pull_request' && 'nothing') || 'linux/arm/v7' }}
     steps:
+      - name: List CPU
+        run: lscpu
+
       - name: Checkout repository
         uses: actions/checkout@v4
 


### PR DESCRIPTION
This PR adds some debug output to the github action to show the actual hardware the job is running on, to find out why sometimes builds are very slow