### PR TITLE
Enable MQTT clusters

### DIFF
--- a/_version.py
+++ b/_version.py
@@ -2,4 +2,4 @@
 Kraken version information.
 """
 
-__version__ = "4.4.0"
+__version__ = "4.5.0"

--- a/kraken_ethernet.py
+++ b/kraken_ethernet.py
@@ -110,14 +110,11 @@ class Kraken:
     @staticmethod
     def load_mqtt_parameters() -> MQTTParams:
         """Loads MQTT broker parameters from env variables"""
-        result: MQTTParams = {
-            "hostname": config("MQTT_HOST"),
-            "port": config("MQTT_PORT", cast=int, default=1883),
-            "username": load_secret("MQTT_CLIENT_USER", default=None),
-            "password": load_secret("MQTT_CLIENT_PASSWORD", default=None),
-        }
-
-        return result
+        return MQTTParams(
+            hosts=config("MQTT_HOST"),
+            username=load_secret("MQTT_CLIENT_USER", default=None),
+            password=load_secret("MQTT_CLIENT_PASSWORD", default=None),
+        )
 
     async def run(self):  # pylint: disable=too-many-locals
         """

--- a/tests/test_env_parser.py
+++ b/tests/test_env_parser.py
@@ -1,0 +1,44 @@
+"""
+Tests for the input environment variable parser.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from managers import MQTTParams
+
+
+@pytest.mark.parametrize(
+    ["hosts", "result"],
+    [
+        ["example.com", [("example.com", 1883)]],
+        ["example.com:1234", [("example.com", 1234)]],
+        ["example1.com,example2.com", [("example1.com", 1883), ("example2.com", 1883)]],
+        ["example1.com, example2.com", [("example1.com", 1883), ("example2.com", 1883)]],
+        ["example1.com:1234,example2.com", [("example1.com", 1234), ("example2.com", 1883)]],
+        ["example1.com:1234,example2.com:0", [("example1.com", 1234), ("example2.com", 1883)]],
+    ],
+)
+def test_mqtt_hostnames_pass(hosts, result):
+    """
+    Test parsing hostname(s) from env variables.
+    """
+    env_params = MQTTParams(hosts=hosts, identifier="foo", username="bar", password="12345")
+
+    assert env_params.hosts == result
+
+
+@pytest.mark.parametrize(
+    ["hosts", "expectation"],
+    [
+        ["example.com:123456", pytest.raises(ValidationError)],
+        ["e^xample.com", pytest.raises(ValidationError)],
+        ["example.com:-1", pytest.raises(ValidationError)],
+    ],
+)
+def test_mqtt_hostnames_fail(hosts, expectation):
+    """
+    Test parsing hostname(s) from env variables. Test invalid hostnames.
+    """
+    with expectation:
+        MQTTParams(hosts=hosts, identifier="foo", username="bar", password="12345")


### PR DESCRIPTION
This PR allows to add multiple MQTT servers to be used as a cluster. The MQTT client will automatically fail over and try to connect to next MQTT server in line.